### PR TITLE
specified pytorch version to fix build error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
       - moviepy
       - matplotlib
       - scipy>=1.6.0
-  - pytorch
+  - pytorch=1.11.0
   - torchvision
   - cudatoolkit
   - tqdm


### PR DESCRIPTION
As discussed in [#106 issue](https://github.com/sxyu/svox2/issues/106) , 
Currently, `pip install` step tends to occur unknown build error. I figured out that it was due to pytorch version mismatch.

Need to specify pytorch version to 1.11.0 in `environment.yml`. After changing, the installation, optimizing, and rendering step all worked fine.